### PR TITLE
Fix padding constant misuse

### DIFF
--- a/dyna/module/dynamic_conv2d_delta.py
+++ b/dyna/module/dynamic_conv2d_delta.py
@@ -401,7 +401,7 @@ class DynamicConv2DDelta(nn.Module):
                     ]
                 ),
                 mode="constant",
-                value=1.0,
+                value=0.0,
             )
             x_padding = (x_padded_ones - x_padded_zeros) * self.padding_dynamic_value
             x = x_padded_zeros + x_padding
@@ -410,7 +410,7 @@ class DynamicConv2DDelta(nn.Module):
                 input=x,
                 pad=self.padding,
                 mode="constant",
-                value=None,
+                value=0.0,
             )
 
         batched_fn = torch.vmap(wrapped_fn)

--- a/dyna/module/dynamic_conv2d_mobius.py
+++ b/dyna/module/dynamic_conv2d_mobius.py
@@ -407,7 +407,7 @@ class DynamicConv2DMobius(nn.Module):
 
         x = x + self.offset_dynamic_value if self.offset_dynamic else x
 
-        if self.padding_dynamic_value:
+        if self.padding_dynamic_value is not None:
             x_padded_ones = F.pad(
                 input=x,
                 pad=(
@@ -436,7 +436,7 @@ class DynamicConv2DMobius(nn.Module):
                     ]
                 ),
                 mode="constant",
-                value=1.0,
+                value=0.0,
             )
             x_padding = (x_padded_ones - x_padded_zeros) * self.padding_dynamic_value
             x = x_padded_zeros + x_padding
@@ -445,7 +445,7 @@ class DynamicConv2DMobius(nn.Module):
                 input=x,
                 pad=self.padding,
                 mode="constant",
-                value=self.padding_dynamic_value if self.padding_dynamic else None,
+                value=0.0,
             )
 
         batched_fn = torch.vmap(wrapped_fn)


### PR DESCRIPTION
## Summary
- correct constant padding values in DynamicConv2DDelta
- fix pad value handling in DynamicConv2DMobius

## Testing
- `python -m py_compile dyna/module/dynamic_conv2d_delta.py dyna/module/dynamic_conv2d_mobius.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6aa6510c83319d1cee3ce6aa7d1a